### PR TITLE
Chore: write remote origin config to file

### DIFF
--- a/ClashX/General/Managers/RemoteConfigManager.swift
+++ b/ClashX/General/Managers/RemoteConfigManager.swift
@@ -79,9 +79,8 @@ class RemoteConfigManager: NSObject {
                             }
                         }
                         
-                        let newConfigStringToWrite = try Yams.dump(object: originConfig)
                         try FileManager.default.removeItem(atPath: kDefaultConfigFilePath)
-                        try newConfigStringToWrite.write(toFile: kDefaultConfigFilePath, atomically: true, encoding: .utf8)
+                        try newConfigString.write(toFile: kDefaultConfigFilePath, atomically: true, encoding: .utf8)
                         NotificationCenter.default.post(Notification(name: kShouldUpDateConfig))
                         self.alert(with: "Success!")
                         replaceSuccess = true


### PR DESCRIPTION
1. 将原始的远程的配置写入到文件比较好，这样和远程的文件对比的时候就非常方便了。 
2. 如果远程的文件yaml不对，load的时候就会报错。所以不用再dump写入了。直接将原始的写入，如果错了可以直接手动对比。