### PR TITLE
List Trojan as a supported protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A rule based proxy For Mac base on [Clash](https://github.com/Dreamacro/clash).
 - HTTP/HTTPS and SOCKS protocol
 - Surge like configuration
 - GeoIP rule support
-- Support Vmess/Shadowsocks/Socks5
+- Support Vmess/Shadowsocks/Socks5/Trojan
 - Support for Netfilter TCP redirect
 
 ## Install


### PR DESCRIPTION
# Example macOS clashX config using Trojan
```
port: 7890
socks-port: 7891
redir-port: 7892
allow-lan: false
mode: Rule
log-level: silent
external-controller: '0.0.0.0:9090'
secret: ''
proxies:
  - name: 'my trojan proxy'
    type: trojan
    server: eg.wonderful.me
    port: 443
    password: YOUR_PASSWORD
    alpn:
      - h2
      - http/1.1
```