### PR TITLE
Fix: Log 日期对不上 #370

### DIFF
--- a/ClashX/Basic/Logger.swift
+++ b/ClashX/Basic/Logger.swift
@@ -16,6 +16,10 @@ class Logger {
         #if DEBUG
             DDLog.add(DDOSLogger.sharedInstance)
         #endif
+        //default time zone is "UTC"
+        let dataFormatter = DateFormatter()
+        dataFormatter.setLocalizedDateFormatFromTemplate("YYYY/MM/dd HH:mm:ss:SSS")
+        fileLogger.logFormatter = DDLogFileFormatterDefault.init(dateFormatter: dataFormatter)
         fileLogger.rollingFrequency = TimeInterval(60 * 60 * 24) // 24 hours
         fileLogger.logFileManager.maximumNumberOfLogFiles = 3
         DDLog.add(fileLogger)


### PR DESCRIPTION
Fix:Log 日期对不上 #370

Root cause: default time zone is "UTC"