### PR TITLE
Use AF validation to discard invalid http status codes

### DIFF
--- a/ClashX/General/Managers/RemoteConfigManager.swift
+++ b/ClashX/General/Managers/RemoteConfigManager.swift
@@ -146,7 +146,9 @@ class RemoteConfigManager {
         }
         urlRequest.cachePolicy = .reloadIgnoringCacheData
 
-        AF.request(urlRequest).responseString(encoding: .utf8) { res in
+        AF.request(urlRequest)
+          .validate()
+          .responseString(encoding: .utf8) { res in
             complete(try? res.result.get(), res.response?.suggestedFilename)
         }
     }


### PR DESCRIPTION
Use AlamoFire validation to only accept valid http status codes (200<300) when downloading a configuration file.

This solves one of the issues explained in #419