### PR TITLE
Fix typos

### DIFF
--- a/ClashX/General/Managers/PrivilegedHelperManager.swift
+++ b/ClashX/General/Managers/PrivilegedHelperManager.swift
@@ -14,7 +14,7 @@ import RxCocoa
 class PrivilegedHelperManager {
     let isHelperCheckFinished = BehaviorRelay<Bool>(value: false)
     private var cancelInstallCheck = false
-    private var useLecgyInstall = false
+    private var useLegacyInstall = false
 
     private var authRef: AuthorizationRef?
     private var connection: NSXPCConnection?
@@ -96,7 +96,7 @@ class PrivilegedHelperManager {
         // Check if the authorization went succesfully
         guard authStatus == errAuthorizationSuccess else {
             Logger.log("Couldn't obtain admin privileges: \(authStatus)", level: .error)
-            return .getAdmainFail
+            return .getAdminFail
         }
 
         // Launch the privileged helper using SMJobBless tool
@@ -194,8 +194,8 @@ extension PrivilegedHelperManager {
             return
         }
 
-        if useLecgyInstall {
-            useLecgyInstall = false
+        if useLegacyInstall {
+            useLegacyInstall = false
             legacyInstallHelper()
             if !cancelInstallCheck {
                 checkInstall()
@@ -208,7 +208,7 @@ extension PrivilegedHelperManager {
             return
         }
         result.alertAction()
-        useLecgyInstall = result.shouldRetryLegacyWay()
+        useLegacyInstall = result.shouldRetryLegacyWay()
         NSAlert.alert(with: result.alertContent)
         if !cancelInstallCheck {
             checkInstall()
@@ -217,10 +217,10 @@ extension PrivilegedHelperManager {
 
     private func showInstallHelperAlert() -> Bool {
         let alert = NSAlert()
-        alert.messageText = NSLocalizedString("ClashX needs to install/update a helper tool with administrator privileges to set system proxy quickly.If not helper tool installed, ClashX won't be able to set your system proxy", comment: "")
+        alert.messageText = NSLocalizedString("ClashX needs to install/update a helper tool with administrator privileges, otherwise ClashX won't be able to configure system proxy.", comment: "")
         alert.alertStyle = .warning
-        if useLecgyInstall {
-            alert.addButton(withTitle: NSLocalizedString("Lecgy Install", comment: ""))
+        if useLegacyInstall {
+            alert.addButton(withTitle: NSLocalizedString("Legacy Install", comment: ""))
         } else {
             alert.addButton(withTitle: NSLocalizedString("Install", comment: ""))
         }
@@ -253,15 +253,15 @@ fileprivate struct AppAuthorizationRights {
 fileprivate enum DaemonInstallResult {
     case success
     case authorizationFail
-    case getAdmainFail
+    case getAdminFail
     case blessError(Int)
 
     var alertContent: String {
         switch self {
         case .success:
             return ""
-        case .authorizationFail: return "Create authorization fail!"
-        case .getAdmainFail: return "Get admain authorization fail!"
+        case .authorizationFail: return "Failed to create authorization!"
+        case .getAdminFail: return "Failed to get admin authorization!"
         case let .blessError(code):
             switch code {
             case kSMErrorInternalFailure: return "blessError: kSMErrorInternalFailure"

--- a/ClashX/Support Files/en.lproj/Localizable.strings
+++ b/ClashX/Support Files/en.lproj/Localizable.strings
@@ -29,7 +29,7 @@
 "ClashX fail to create ~/.config/clash folder. Please check privileges or manually create folder and restart ClashX." = "ClashX fail to create ~/.config/clash folder. Please check privileges or manually create folder and restart ClashX.";
 
 /* No comment provided by engineer. */
-"ClashX needs to install/update a helper tool with administrator privileges to set system proxy quickly.If not helper tool installed, ClashX won't be able to set your system proxy" = "ClashX needs to install/update a helper tool with administrator privileges to set system proxy quickly.If not helper tool installed, ClashX won't be able to set your system proxy";
+"ClashX needs to install/update a helper tool with administrator privileges, otherwise ClashX won't be able to configure system proxy." = "ClashX needs to install/update a helper tool with administrator privileges, otherwise ClashX won't be able to configure system proxy.";
 
 /* No comment provided by engineer. */
 "ClashX Start Error!" = "ClashX Start Error!";
@@ -74,7 +74,7 @@
 "Invalid input" = "Invalid input";
 
 /* No comment provided by engineer. */
-"Lecgy Install" = "Lecgy Install";
+"Legacy Install" = "Legacy Install";
 
 /* No comment provided by engineer. */
 "Need to Restart the ClashX to Take effect, Please start clashX manually" = "Need to Restart the ClashX to Take effect, Please start clashX manually";

--- a/ClashX/Support Files/zh-Hans.lproj/Localizable.strings
+++ b/ClashX/Support Files/zh-Hans.lproj/Localizable.strings
@@ -29,7 +29,7 @@
 "ClashX fail to create ~/.config/clash folder. Please check privileges or manually create folder and restart ClashX." = "ClashX 创建 ~/.config/clash 文件夹失败，请检查权限设置或者手动创建文件夹后重启 ClashX";
 
 /* No comment provided by engineer. */
-"ClashX needs to install/update a helper tool with administrator privileges to set system proxy quickly.If not helper tool installed, ClashX won't be able to set your system proxy" = "ClashX 需要使用管理员权限安装/更新一个帮助程序来帮助设置系统代理。如不安装,ClashX的设置系统代理功能将失效。";
+"ClashX needs to install/update a helper tool with administrator privileges, otherwise ClashX won't be able to configure system proxy." = "ClashX 需要使用管理员权限安装/更新一个帮助程序，否则 ClashX 将无法设置系统代理。";
 
 /* No comment provided by engineer. */
 "ClashX Start Error!" = "ClashX 启动出错";
@@ -74,7 +74,7 @@
 "Invalid input" = "输入不合法";
 
 /* No comment provided by engineer. */
-"Lecgy Install" = "传统安装";
+"Legacy Install" = "传统安装";
 
 /* No comment provided by engineer. */
 "Need to Restart the ClashX to Take effect, Please start clashX manually" = "需要重启ClashX生效，请手动启动ClashX";


### PR DESCRIPTION
- `Lecgy` -> `Legacy`
- `Admain` -> `Admin`
- Rewrite message text for helper tool installation to make it more concise